### PR TITLE
Add Leap 15.3 QU1 and 15.4 configs poo#99954

### DIFF
--- a/publish_leap154.config
+++ b/publish_leap154.config
@@ -1,7 +1,7 @@
 # vim:syntax=sh
 
-leap_version=15.3
-qu="-2" # empty string for GA, QuarterlyUpdate repins have -N in version
+leap_version=15.4
+qu="" # empty string for GA, QuarterlyUpdate repins have -N in version
 logfile_base=~/publish_logs/$leap_version/$(date -d "$date" '+%Y/%m/%d/%H%M')
 synclog="${logfile_base}.log"
 deletelog="${logfile_base}-deletes.log"


### PR DESCRIPTION
* Introduce qu variable which supplies -2 -3 or generally nth respin
  which is necessary for publishing of Leap 15.X Quarterly Updates
  as filenames contain 15.X-n