### PR TITLE
initial copy of appliances and live config for 15.4

### DIFF
--- a/publish_leap154_appliances.config
+++ b/publish_leap154_appliances.config
@@ -1,0 +1,62 @@
+# vim:syntax=sh
+
+leap_version=15.4
+logfile_base=~/publish_logs/$leap_version-appliances/$(date -d "$date" '+%Y/%m/%d/%H%M')
+synclog="${logfile_base}.log"
+deletelog="${logfile_base}-deletes.log"
+path="/distribution/leap/$leap_version/appliances"
+flavors=(kvm-and-xen MS-HyperV OpenStack-Cloud VMware)
+repos=()
+extra_repos=()
+isodir=""
+
+get_version() {
+	# get expected version from first flavor
+	if [ -z "$version" ]; then
+		version=`echo $stage/openSUSE-Leap-$leap_version-JeOS.x86_64-$leap_version-$flavor-Build*.qcow2`
+		version=${version##*Build}
+		version=${version%.*}
+		if [ -z "$version" ]; then
+			echo "no version found, exit." | tee -a $synclog
+			exit 1
+		fi
+	fi
+}
+
+_get_iso()
+{
+	local snapshot="$1"
+	local suffix=qcow2
+	if [ "$flavor" = 'MS-HyperV' ]; then
+		suffix=vhdx.xz
+	elif [ "$flavor" = 'VMware' ]; then
+		suffix=vmdk.xz
+	fi
+#	echo "openSUSE-Leap-$leap_version-JeOS.x86_64-$leap_version.0-$flavor-$snapshot.$suffix"
+	echo "openSUSE-Leap-$leap_version-JeOS.x86_64-$leap_version-$flavor-$snapshot.$suffix"
+}
+
+get_iso()
+{
+	iso=`_get_iso "Build$version"`
+}
+
+get_iso_link()
+{
+	link="$stage/`_get_iso Current`"
+}
+
+get_diff_url()
+{
+	url=""
+}
+
+get_mark_published_url()
+{
+	url=""
+}
+
+get_changes_filename()
+{
+	changes=""
+}

--- a/publish_leap154_live.config
+++ b/publish_leap154_live.config
@@ -1,0 +1,49 @@
+# vim:syntax=sh
+
+leap_version=15.4
+logfile_base=~/publish_logs/$leap_version-live/$(date -d "$date" '+%Y/%m/%d/%H%M')
+synclog="${logfile_base}.log"
+deletelog="${logfile_base}-deletes.log"
+path="/distribution/leap/$leap_version/live"
+flavors=(GNOME-Live-x86_64 KDE-Live-x86_64 Rescue-CD-x86_64)
+repos=()
+extra_repos=()
+isodir=""
+
+get_version() {
+	# get expected version from first flavor
+	if [ -z "$version" ]; then
+		version=`echo $stage/openSUSE-Leap-$leap_version-$flavor-Snapshot*-Media.iso`
+		version=${version##*Snapshot}
+		version=${version%-*}
+		if [ -z "$version" ]; then
+			echo "no version found, exit." | tee -a $synclog
+			exit 1
+		fi
+	fi
+}
+
+get_iso()
+{
+	iso="openSUSE-Leap-$leap_version-$flavor-Snapshot$version-Media.iso"
+}
+
+get_iso_link()
+{
+	link="$stage/openSUSE-Leap-$leap_version-$flavor-Current.iso"
+}
+
+get_diff_url()
+{
+	url=""
+}
+
+get_mark_published_url()
+{
+	url=""
+}
+
+get_changes_filename()
+{
+	changes=""
+}


### PR DESCRIPTION
We should perhaps consider using -Media symlinks instead of -Current just like we've recently started to do for 15.4 base.